### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 1.3.0
+
+### Features
+
+- Implemented branch types directly in the main options ([PR 5](https://github.com/daniloprates/branch-slug/pull/5))
+
+
 ## 1.2.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ GitFlow-like branch naming slugify for lazy people
 
 ## Usage:
 
-* bslug [options]
+```shell
+$ bslug [options]
+```
 
 ### Examples:
 
@@ -21,44 +23,34 @@ $ bslug [ABC-123] Create that awesome feature -f
 
 * Don't include git command for new branch "git branch -m"
 <pre>
-$ bslug [ABC-123] Create that awesome feature -f -g 
+$ bslug [ABC-321] Fix that nasty bug -i -g 
 
 # Outputs
-<b>Branch Slug:</b> <i>feature/abc-123-create-that-awesome-feature</i> copied to clipboard
+<b>Branch Slug:</b> <i>fix/abc-321-fix-that-nasty-bug</i> copied to clipboard
 </pre>
 
 * Don't copy to clipboard
 <pre>
-$ bslug [ABC-123] Create that awesome feature -f -c 
+$ bslug [ABC-456] Improve our workflow -c -n 
 
 # Outputs
-<b>Branch Slug:</b> <i>git branch -m feature/abc-123-create-that-awesome-feature</i>
+<b>Branch Slug:</b> <i>git branch -m chore/abc-456-improve-our-workflow</i>
 </pre>
 
 
 ## Options:
 
-```
-  -g, --no-git        Don't include git command for new branch "git branch -m"
-  -c, --no-copy       Don't copy output to the clipboard
-  -t, --type <typet>  Branch type. The output is {type}/{description}
+```shell
+  -g, --no-git        Don't include git command for new branch git branch -m
+  -n, --no-copy       Don't copy output to the clipboard
+  -f, --type-feature  Branch type: feature. The output is feature/{description
+  -i, --type-fix      Branch type: fix. The output is fix/{description
+  -b, --type-bug      Branch type: bug. The output is bug/{description
+  -c, --type-chore    Branch type: chore. The output is chore/{description
+  -r, --type-release  Branch type: release. The output is release/{description
+  -t, --type <type>   Custom branch type. The output is {type}/{description}
   -h, --help          output usage information
 ```
-
-## Types:
-
-`-t {type}`
-
-```
-  f or fe for feature
-  fi for fix
-  b for bug
-  c for chore
-  r for release
-  or any other custom type e.g. special
-```
-
-
 
 
 

--- a/index.js
+++ b/index.js
@@ -5,20 +5,14 @@ var clipboardy = require('clipboardy');
 var chalk = require('chalk');
 
 program
-  .option('-g, --no-git', 'Don\'t include git command for new branch "git branch -m"')
-  .option('-c, --no-copy', 'Don\'t copy output to the clipboard')
-  .option('-t, --type <typet>', 'Branch type. The output is {type}/{description}');
-
-program.on('--help', function(){
-  console.log(`
-Types (-t {type}):
-  ${chalk.greenBright.bold('f')} or ${chalk.greenBright.bold('fe')} for ${chalk.blueBright('feature')}
-  ${chalk.greenBright.bold('fi')} for ${chalk.blueBright('fix')}
-  ${chalk.greenBright.bold('b')} for ${chalk.blueBright('bug')}
-  ${chalk.greenBright.bold('c')} for ${chalk.blueBright('chore')}
-  ${chalk.greenBright.bold('r')} for ${chalk.blueBright('release')}
-  or any other custom type e.g. ${chalk.greenBright.bold('special')}`)
-});
+  .option('-g, --no-git', chalk.magenta(`Don\'t include git command for new branch ${chalk.italic.bold('git branch -m')}`))
+  .option('-n, --no-copy', chalk.magenta('Don\'t copy output to the clipboard'))
+  .option('-f, --type-feature', chalk.greenBright(`Branch type: ${chalk.blueBright('feature')}. The output is ${chalk.blue.bold('feature/{description')}`))
+  .option('-i, --type-fix', chalk.greenBright(`Branch type: ${chalk.blueBright('fix')}. The output is ${chalk.blue.bold('fix/{description')}`))
+  .option('-b, --type-bug', chalk.greenBright(`Branch type: ${chalk.blueBright('bug')}. The output is ${chalk.blue.bold('bug/{description')}`))
+  .option('-c, --type-chore', chalk.greenBright(`Branch type: ${chalk.blueBright('chore')}. The output is ${chalk.blue.bold('chore/{description')}`))
+  .option('-r, --type-release', chalk.greenBright(`Branch type: ${chalk.blueBright('release')}. The output is ${chalk.blue.bold('release/{description')}`))
+  .option('-t, --type <type>', chalk.greenBright(`Custom branch type. The output is ${chalk.blue.bold('{type}/{description}')}`));
 
 program.parse(process.argv);
 
@@ -42,13 +36,16 @@ var args = process.argv
 
 var gitCommand = program.git ? 'git branch -m ' : '';
 var type = program.type || '';
-if (type === 'f' || type === 'fe') type = 'feature';
-else if (type === 'fi') type = 'fix';
-else if (type === 'b') type = 'bug';
-else if (type === 'c') type = 'chore';
-else if (type === 'r') type = 'release';
+if (program.typeFeature) type = 'feature';
+else if (program.typeFix) type = 'fix';
+else if (program.typeBug) type = 'bug';
+else if (program.typeChore) type = 'chore';
+else if (program.typeRelease) type = 'release';
 if (type) type+='/'
-var description = slug(args.join('-'), { lower: true });
+var description = slug(args.join('-'), { lower: true, remove: /[.]/g });
+if (!description) {
+  return
+}
 var copyOutput = gitCommand + type + description;
 var printOutput = chalk.greenBright.bold(copyOutput);
 if (program.copy) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-slug",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Implements branch types directly in the main options:

```shell
Usage: branch-slug [options]

Options:
  -g, --no-git        Don't include git command for new branch git branch -m
  -n, --no-copy       Don't copy output to the clipboard
  -f, --type-feature  Branch type: feature. The output is feature/{description
  -i, --type-fix      Branch type: fix. The output is fix/{description
  -b, --type-bug      Branch type: bug. The output is bug/{description
  -c, --type-chore    Branch type: chore. The output is chore/{description
  -r, --type-release  Branch type: release. The output is release/{description
  -t, --type <type>   Custom branch type. The output is {type}/{description}
  -h, --help          output usage information
```

